### PR TITLE
Performance improvements

### DIFF
--- a/generate.rb
+++ b/generate.rb
@@ -1,7 +1,12 @@
+STDOUT.sync = true
 require 'csv'
 require 'pry'
 require_relative 'lib/pdex'
 
-PDEX::NPPESDataLoader.load
+mode = ENV['LOAD'] == 'pharmacy' ? :pharmacy : :providers
 
-PDEX::FHIRGenerator.generate
+puts "Loading NPPES data"
+PDEX::NPPESDataLoader.load(mode)
+
+puts "Generating FHIR data"
+PDEX::FHIRGenerator.generate(mode)

--- a/lib/pdex.rb
+++ b/lib/pdex.rb
@@ -28,7 +28,6 @@ module PDEX
   HEALTHCARE_SERVICE_PROFILE_URL = 'http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-HealthcareService'
   INSURANCE_PLAN_PROFILE_URL = 'http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-InsurancePlan'
   NETWORK_PROFILE_URL = 'http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Network'
-  PRACTITIONER_PROFILE_URL = 'http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Practitioner'
   PRACTITIONER_ROLE_PROFILE_URL = 'http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-PractitionerRole'
   ORGANIZATION_PROFILE_URL = 'http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization'
   ORGANIZATION_AFFILIATION_PROFILE_URL = 'http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-OrganizationAffiliation'

--- a/lib/pdex/nppes_data_repo.rb
+++ b/lib/pdex/nppes_data_repo.rb
@@ -41,18 +41,15 @@ module PDEX
       DEFAULT_STATE = 'MA'
 
       def networks_by_state(state)
-        @networks_by_state ||= networks.group_by { |network| network.address.state }
-        @networks_by_state[state] || @networks_by_state[DEFAULT_STATE]
+        networks.filter{|network| network.address.state == state}
       end
 
       def managing_orgs_by_state(state)
-        @managing_orgs_by_state ||= managing_orgs.group_by { |org| org.address.state }
-        @managing_orgs_by_state[state] || @managing_orgs_by_state[DEFAULT_STATE]
+        managing_orgs.filter{|org| org.address.state == state}
       end
 
       def organizations_by_state(state)
-        @organizations_by_state ||= organizations.group_by { |org| org.address.state }
-        @organizations_by_state[state] || @organizations_by_state[DEFAULT_STATE]
+        organizations.filter{|org| org.address.state == state}
       end
     end
   end

--- a/lib/pdex/nppes_practitioner.rb
+++ b/lib/pdex/nppes_practitioner.rb
@@ -9,11 +9,12 @@ module PDEX
     attr_reader :raw_data
 
     def initialize(raw_data)
-      @raw_data = raw_data.freeze
+      @raw_data = raw_data.to_hash.select {|k,v| v != '' }
+      @raw_data.default = ''
     end
 
     def npi
-      @npi ||= raw_data['NPI']
+      raw_data['NPI']
     end
 
     def name
@@ -30,23 +31,23 @@ module PDEX
     end
 
     def first_name
-      @first_name ||= raw_data['Provider First Name']
+      raw_data['Provider First Name']
     end
 
     def middle_name
-      @middle_name ||= raw_data['Provider Middle Name']
+      raw_data['Provider Middle Name']
     end
 
     def last_name
-      @last_name ||= raw_data['Provider Last Name (Legal Name)']
+      raw_data['Provider Last Name (Legal Name)']
     end
 
     def phone_numbers
-      @phone_numbers ||= [raw_data['Provider Business Practice Location Address Telephone Number']]
+      [raw_data['Provider Business Practice Location Address Telephone Number']]
     end
 
     def fax_numbers
-      @fax_numbers ||= [raw_data['Provider Business Practice Location Address Fax Number']]
+      [raw_data['Provider Business Practice Location Address Fax Number']]
     end
 
     def address

--- a/lib/pdex/practitioner_factory.rb
+++ b/lib/pdex/practitioner_factory.rb
@@ -6,13 +6,69 @@ require_relative 'telecom'
 require_relative 'utils/states'
 require_relative 'utils/nucc_codes'
 
+PROFICIENCIES = [
+      {
+        code: '10',
+        display: 'Elementary proficiency'
+      },
+      {
+        code: '20',
+        display: 'Limited working proficiency'
+      },
+      {
+        code: '30',
+        display: 'General professional proficiency'
+      },
+      {
+        code: '40',
+        display: 'Advanced professional proficiency'
+      },
+      {
+        code: '50',
+        display: 'Functional native proficiency'
+      }
+    ]
+
+languages = [
+        {
+          code: 'ht',
+          display: 'Haitian'
+        },
+        {
+          code: 'zh',
+          display: 'Chinese'
+        },
+        {
+          code: 'es',
+          display: 'Spanish'
+        },
+        {
+          code: 'pt',
+          display: 'Portuguese'
+        },
+        {
+          code: 'vi',
+          display: 'Vietnamese'
+        }
+      ]
+
 module PDEX
+
+  PRACTITIONER_PROFILE_URL = 'http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Practitioner'
+
   class PractitionerFactory
     include Address
     include FHIRElements
     include Telecom
 
     attr_reader :source_data
+
+    @@meta =
+      {
+        profile: [PRACTITIONER_PROFILE_URL],
+        versionId: '1',
+        lastUpdated: '2020-08-17T10:03:10Z'
+      }
 
     def initialize(nppes_practitioner)
       @source_data = nppes_practitioner
@@ -22,7 +78,7 @@ module PDEX
       FHIR::Practitioner.new(
         {
           id: id,
-          meta: meta,
+          meta: @@meta,
           identifier: identifier,
           active: true,
           name: name,
@@ -39,14 +95,6 @@ module PDEX
 
     def id
       "practitioner-#{source_data.npi}"
-    end
-
-    def meta
-      {
-        profile: [PRACTITIONER_PROFILE_URL],
-        versionId: '1',
-        lastUpdated: '2020-08-17T10:03:10Z'
-      }
     end
 
     def identifier
@@ -196,28 +244,7 @@ module PDEX
     end
 
     def second_language(n)
-      language = [
-        {
-          code: 'ht',
-          display: 'Haitian'
-        },
-        {
-          code: 'zh',
-          display: 'Chinese'
-        },
-        {
-          code: 'es',
-          display: 'Spanish'
-        },
-        {
-          code: 'pt',
-          display: 'Portuguese'
-        },
-        {
-          code: 'vi',
-          display: 'Vietnamese'
-        }
-      ][n]
+      language = languages[n]
 
       return if language.blank?
 
@@ -233,29 +260,6 @@ module PDEX
         extension: [proficiency_extension]
       }
     end
-
-    PROFICIENCIES = [
-      {
-        code: '10',
-        display: 'Elementary proficiency'
-      },
-      {
-        code: '20',
-        display: 'Limited working proficiency'
-      },
-      {
-        code: '30',
-        display: 'General professional proficiency'
-      },
-      {
-        code: '40',
-        display: 'Advanced professional proficiency'
-      },
-      {
-        code: '50',
-        display: 'Functional native proficiency'
-      }
-    ]
 
     def proficiency_extension(fluent = false)
       proficiency =

--- a/lib/pdex/practitioner_generator.rb
+++ b/lib/pdex/practitioner_generator.rb
@@ -33,7 +33,7 @@ module PDEX
     end
 
     def organization
-      return nil if organizations.nil?
+      return nil if organizations.nil? || organizations.length == 0
       organizations[nppes_data.npi.to_i % organizations.length]
     end
 

--- a/lib/pdex/practitioner_role_factory.rb
+++ b/lib/pdex/practitioner_role_factory.rb
@@ -117,8 +117,7 @@ module PDEX
 
     def specialty
       source_data.qualifications
-        .map { |qualification| nucc_codeable_concept(qualification) }
-        .first
+        .find { |qualification| nucc_codeable_concept(qualification) }
     end
 
     def location


### PR DESCRIPTION
- Stop memoizing a bunch of stuff that goes unused later
- Allow for separate runs for providers and pharmacies
- Add some parallelization to provider loading and provider and pharmacy org file generation
  - Ruby has a global interpreter lock that only unlocks when one thread is doing IO, so use tiny thread pools to minimize lock contention
- Other random perf improvements like lifting things up to constants to cut down on regeneration of static values

- I'll have two follow-ups in the core repo: One that updates the makefile to run pharmacies in parallel with providers, and then another to flatten this repo into the monorepo; upstream doesn't appear to be updated any more and we're wildly diverging here
- This thing was hanging at 32gb mem, it now runs with a mem peak of ~4gb and finishes in ~55m